### PR TITLE
check item length

### DIFF
--- a/base.py
+++ b/base.py
@@ -69,7 +69,7 @@ class NDList(list):
         item = self
         while isinstance(item, list):
             shape.append(len(item))
-            item = item[0]
+            item = item[0] if len(item) > 0 else None
         return tuple(shape)
 
     @property


### PR DESCRIPTION
fixes bug where exception is raised within shape for empty NDList instances

shape of empty NDList now returns `(0,)`, as expected

I know there are PEP8 issues, they are fixed in #20 

❤️ 